### PR TITLE
Add selectable visual styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A retro-styled Pong game built with HTML5 Canvas and JavaScript. Experience the 
 - **Mouse Controls**: Smooth paddle movement using mouse input
 - **Visual Effects**: Ball trail effects for enhanced visual appeal
 - **Retro Styling**: Classic black and white design with pixelated rendering
+- **Theme Selector**: Choose between Retro, MS-DOS, and Hacker color schemes
 - **Responsive Scoring**: Real-time score tracking
 - **Ball Physics**: Realistic collision detection and ball acceleration
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,15 @@
     <title>Retro Pong</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="retro">
+    <div id="style-menu">
+        <label for="style-select">Style:</label>
+        <select id="style-select">
+            <option value="retro">Retro Terminal</option>
+            <option value="msdos">MS-DOS Editor</option>
+            <option value="hacker">Hacker</option>
+        </select>
+    </div>
     <div id="game-container">
         <canvas id="game-canvas" width="900" height="700"></canvas>
         <div id="score">0 : 0</div>

--- a/pong.js
+++ b/pong.js
@@ -33,8 +33,17 @@ function init() {
     // Add event listeners
     document.getElementById('start-button').addEventListener('click', startGame);
     canvas.addEventListener('mousemove', movePaddle);
+    document.getElementById('style-select').addEventListener('change', changeStyle);
 
     // Initial render
+    render();
+}
+
+// Change visual style
+function changeStyle(e) {
+    document.body.classList.remove('retro', 'msdos', 'hacker');
+    document.body.classList.add(e.target.value);
+    // Re-render to apply new colors immediately
     render();
 }
 
@@ -151,12 +160,19 @@ function updateBall() {
 
 // Render the game
 function render() {
+    // Get colors from CSS variables
+    const styles = getComputedStyle(document.body);
+    const bgColor = styles.getPropertyValue('--bg-color');
+    const paddleColor = styles.getPropertyValue('--paddle-color');
+    const ballColor = styles.getPropertyValue('--ball-color');
+    const lineColor = styles.getPropertyValue('--border-color');
+
     // Clear the canvas
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = bgColor;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     // Draw center line
-    ctx.strokeStyle = '#fff';
+    ctx.strokeStyle = lineColor || paddleColor;
     ctx.setLineDash([10, 15]);
     ctx.beginPath();
     ctx.moveTo(canvas.width / 2, 0);
@@ -165,7 +181,7 @@ function render() {
     ctx.setLineDash([]);
 
     // Draw paddles
-    ctx.fillStyle = '#fff';
+    ctx.fillStyle = paddleColor;
     ctx.fillRect(0, playerPaddleY, PADDLE_WIDTH, PADDLE_HEIGHT);
     ctx.fillRect(canvas.width - PADDLE_WIDTH, aiPaddleY, PADDLE_WIDTH, PADDLE_HEIGHT);
 
@@ -175,13 +191,15 @@ function render() {
             // Calculate opacity based on position in trail (older = more transparent)
             // i=0 is oldest, i=length-1 is newest
             const opacity = (i + 1) / ballTrail.length * 0.7; // Max opacity of trail is 0.7
-            ctx.fillStyle = `rgba(255, 255, 255, ${opacity})`;
+            ctx.globalAlpha = opacity;
+            ctx.fillStyle = ballColor;
             ctx.fillRect(ballTrail[i].x, ballTrail[i].y, BALL_SIZE, BALL_SIZE);
+            ctx.globalAlpha = 1;
         }
     }
 
     // Draw ball (full opacity)
-    ctx.fillStyle = '#fff';
+    ctx.fillStyle = ballColor;
     ctx.fillRect(ballX, ballY, BALL_SIZE, BALL_SIZE);
 }
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,14 @@
+:root {
+    --bg-color: #000;
+    --text-color: #fff;
+    --border-color: #fff;
+    --button-bg: #fff;
+    --button-color: #000;
+    --overlay-bg: rgba(0, 0, 0, 0.7);
+    --paddle-color: #fff;
+    --ball-color: #fff;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -5,7 +16,8 @@ body {
     justify-content: center;
     align-items: center;
     height: 100vh;
-    background-color: #000;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     font-family: 'Courier New', monospace;
     overflow: hidden;
 }
@@ -14,12 +26,12 @@ body {
     position: relative;
     width: 900px;
     height: 700px;
-    border: 4px solid #fff;
+    border: 4px solid var(--border-color);
     image-rendering: pixelated;
 }
 
 #game-canvas {
-    background-color: #000;
+    background-color: var(--bg-color);
     display: block;
     image-rendering: pixelated;
 }
@@ -29,7 +41,7 @@ body {
     top: 20px;
     left: 0;
     right: 0;
-    color: #fff;
+    color: var(--text-color);
     font-size: 32px;
     text-align: center;
     font-weight: bold;
@@ -45,18 +57,68 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    background-color: rgba(0, 0, 0, 0.7);
-    color: #fff;
+    background-color: var(--overlay-bg);
+    color: var(--text-color);
 }
 
 #start-button {
     margin-top: 20px;
     padding: 10px 20px;
     font-size: 20px;
-    background-color: #fff;
-    color: #000;
+    background-color: var(--button-bg);
+    color: var(--button-color);
     border: none;
     cursor: pointer;
     font-family: 'Courier New', monospace;
     font-weight: bold;
+}
+
+#style-menu {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    color: var(--text-color);
+    z-index: 1000;
+    font-family: 'Courier New', monospace;
+}
+
+#style-menu select {
+    background-color: var(--button-bg);
+    color: var(--button-color);
+    font-family: 'Courier New', monospace;
+    border: none;
+    padding: 2px 4px;
+}
+
+body.retro {
+    --bg-color: #000;
+    --text-color: #fff;
+    --border-color: #fff;
+    --button-bg: #fff;
+    --button-color: #000;
+    --overlay-bg: rgba(0, 0, 0, 0.7);
+    --paddle-color: #fff;
+    --ball-color: #fff;
+}
+
+body.msdos {
+    --bg-color: #0000aa;
+    --text-color: #ffffff;
+    --border-color: #ffffff;
+    --button-bg: #ffffff;
+    --button-color: #0000aa;
+    --overlay-bg: rgba(0, 0, 170, 0.7);
+    --paddle-color: #ffffff;
+    --ball-color: #ffffff;
+}
+
+body.hacker {
+    --bg-color: #000;
+    --text-color: #00ff00;
+    --border-color: #00ff00;
+    --button-bg: #00ff00;
+    --button-color: #000;
+    --overlay-bg: rgba(0, 255, 0, 0.2);
+    --paddle-color: #00ff00;
+    --ball-color: #00ff00;
 }


### PR DESCRIPTION
## Summary
- add theme selector dropdown to the page
- refactor CSS to use variables and define retro, ms-dos and hacker themes
- update game rendering logic to read colors from CSS variables
- update README with a note about the new theme selector

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e797e3ae0833294f6b4b01df02196